### PR TITLE
Add test for #91

### DIFF
--- a/src/pbfont.test.ts
+++ b/src/pbfont.test.ts
@@ -15,6 +15,10 @@ const arialUnicode512 = readTestFont("arialunicode.512.767.pbf");
 const league512 = readTestFont("league.512.767.pbf");
 const composite512 = readTestFont("opensans.arialunicode.512.767.pbf");
 const triple512 = readTestFont("league.opensans.arialunicode.512.767.pbf");
+const metropolis5375 = readTestFont("metropolis.regular.5120-5375.pbf");
+const notoSans5375 = readTestFont("noto.sans.regular.5120-5375.pbf");
+const composite5375 = readTestFont("metropolis.regular.noto.sans.regular.5120-5375.pbf");
+
 
 test("compositing two pbfs", (_t) => {
   const combined = pbfonts.combine([openSans512, arialUnicode512]);
@@ -62,6 +66,16 @@ test("compositing two pbfs", (_t) => {
 });
 test("returns nothing when given nothing", () => {
   expect(pbfonts.combine([])).toBe(undefined);
+});
+
+test("can composite 1kb pbf files", (_t) => {
+  const name = "Metropolis Regular,Noto Sans Regular";
+  const combined = pbfonts.combine([metropolis5375, notoSans5375], name);
+  if (!combined) throw new Error("no combined");
+  const composite = pbfonts.decode(combined);
+  const expected = pbfonts.decode(composite5375);
+
+  expect(composite).toEqual(expected); //, 'can composite 1kb');
 });
 
 test("can composite only one pbf", (_t) => {

--- a/test/fixtures/metropolis.regular.5120-5375.pbf
+++ b/test/fixtures/metropolis.regular.5120-5375.pbf
@@ -1,0 +1,3 @@
+
+
+Metropolis Regular	5120-5375

--- a/test/fixtures/metropolis.regular.noto.sans.regular.5120-5375.pbf
+++ b/test/fixtures/metropolis.regular.noto.sans.regular.5120-5375.pbf
@@ -1,0 +1,3 @@
+
+-
+$Metropolis Regular,Noto Sans Regular0-255

--- a/test/fixtures/noto.sans.regular.5120-5375.pbf
+++ b/test/fixtures/noto.sans.regular.5120-5375.pbf
@@ -1,0 +1,3 @@
+
+î
+àNoto Sans Regular, Noto Naskh Arabic Regular, Noto Sans Armenian Regular, Noto Sans Balinese Regular, Noto Sans Bengali Regular, Noto Sans CJK TC Regular, Noto Sans Devanagari Regular, Noto Sans Ethiopic Regular, Noto Sans Georgian Regular, Noto Sans Gujarati Regular, Noto Sans Gurmukhi Regular, Noto Sans Hebrew Regular, Noto Sans Javanese Regular, Noto Sans Kannada Regular, Noto Sans Khmer Regular, Noto Sans Lao Regular, Noto Sans Mongolian Regular, Noto Sans Myanmar Regular, Noto Sans Oriya Regular, Noto Sans Sinhala Regular, Noto Sans Tamil Regular, Noto Sans Thai Regular, Noto Sans Tibetan Regular	5120-5375


### PR DESCRIPTION
Add test for https://github.com/jessekrubin/pbfont/issues/91 . This test shows the issue I mentioned.  

After https://github.com/jessekrubin/pbfont/pull/93
![image](https://github.com/user-attachments/assets/b9123611-87f5-437a-a2f0-970e50cde6b4)

Before that commit
![image](https://github.com/user-attachments/assets/20b61e08-c080-463e-b6b8-ea7eaad692c4)

